### PR TITLE
Add "Verify commit signatures" support

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -7,7 +7,7 @@
     homeDirectory = "/Users/sjoli";  # paths that will be managed by home-manager
     stateVersion = "23.11";
     sessionVariables = {
-      # NOTE: What should be here
+      GPG_TTY = "${pkgs.coreutils}/bin/tty";
     };
     packages = import ./packages.nix { inherit pkgs; };
   };

--- a/home-manager/programs.nix
+++ b/home-manager/programs.nix
@@ -7,6 +7,10 @@
 
   git = import ./git.nix { inherit pkgs; };
 
+  gpg = {
+    enable = true;
+  };
+
   direnv = {
     enable = true;
     enableZshIntegration = true;

--- a/home-manager/services.nix
+++ b/home-manager/services.nix
@@ -1,0 +1,11 @@
+{ pkgs }:
+let
+  pinentry-mac = pkgs.pinentry_mac;
+in
+{
+  gpg-agent = {
+    enable = false;
+    # pinentryPackage = "${pinentry-mac}/bin/pinentry-mac";
+    # pinentryPackage = "${pinentry-mac}/bin/pinentry-mac"; NOTE: https://github.com/NixOS/nixpkgs/issues/240819
+  };
+}


### PR DESCRIPTION
## Overview

This requires that I install `gpg` and `gpg-agent`, but currently `gpg-agent` [is not supported](https://github.com/nix-community/home-manager/issues/3864) for M1 macs.

## Resources:
- Lack of support for `mac` flavor when selecting pinentry package: https://github.com/NixOS/nixpkgs/issues/240819#issuecomment-1616760598
- Example of successful setup: https://github.com/kachick/dotfiles/pull/311