### PR TITLE
Install and configure yazi

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,28 @@
         "type": "github"
       }
     },
+    "plugin-yazi-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1720016649,
+        "narHash": "sha256-PWpFsmpthYREJI/3NRIKb1Vb9lEv3xeSO+MNXHzyUSg=",
+        "owner": "mikavilpas",
+        "repo": "yazi.nvim",
+        "rev": "a2f7832af7462c79d57777dd8c36ad0edfb84b39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mikavilpas",
+        "repo": "yazi.nvim",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "plugin-cyberpunk": "plugin-cyberpunk"
+        "plugin-cyberpunk": "plugin-cyberpunk",
+        "plugin-yazi-nvim": "plugin-yazi-nvim"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,11 @@
 
         plugin-cyberpunk.url = "github:samueljoli/cyberpunk.nvim";
         plugin-cyberpunk.flake = false;
+
+        plugin-yazi-nvim = {
+          url = "github:mikavilpas/yazi.nvim";
+          flake = false;
+        };
     };
 
     outputs = {nixpkgs, home-manager, ...}@inputs: {

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -11,5 +11,17 @@
     };
     packages = import ./packages.nix { inherit pkgs; };
   };
+  nixpkgs = {
+    overlays = [
+      (final: prev: {
+        vimPlugins = prev.vimPlugins // {
+          foreign-yazi-nvim = prev.vimUtils.buildVimPlugin {
+            name = "yazi";
+            src = inputs.plugin-yazi-nvim;
+          };
+        };
+      })
+    ];
+  };
   programs = import ./programs.nix { inherit pkgs; };
 }

--- a/home-manager/neovim/default.nix
+++ b/home-manager/neovim/default.nix
@@ -17,6 +17,7 @@ in
     ${builtins.readFile ./telescope.lua}
     ${builtins.readFile ./comment.lua}
     ${builtins.readFile ./gitsigns.lua}
+    ${builtins.readFile ./yazi.lua}
   '';
 
   plugins = with vimPlugins; [
@@ -30,5 +31,6 @@ in
     telescope-ui-select-nvim
     vim-nix
     vim-nix
+    vimPlugins.foreign-yazi-nvim
   ];
 }

--- a/home-manager/neovim/yazi.lua
+++ b/home-manager/neovim/yazi.lua
@@ -1,0 +1,5 @@
+local yazi = require("yazi")
+
+vim.keymap.set('n', '<leader>e', yazi.yazi, { desc = 'Open the file manager' })
+
+yazi.setup()


### PR DESCRIPTION
Adds [yazi-nvim](https://github.com/mikavilpas/yazi.nvim) to neovim. Since said package is not packaged as a nix pkg, we needed to extend the base `nixpkgs`. This pull requests serves as a documentation of how to do that.