### PR TITLE
install rustaceanvim

### DIFF
--- a/home-manager/neovim/default.nix
+++ b/home-manager/neovim/default.nix
@@ -70,6 +70,8 @@ in
     cmp_luasnip
     luasnip
     nvim-cmp
+
+    rustaceanvim
   ];
 
   extraLuaPackages = ps: [ ps.jsregexp ];


### PR DESCRIPTION
# Notes
This got me thinking about the developer experience. Is it possible to use home-manager to manage my base neovim config and then have project specific neovim config. That would mean it would need to handle dependencies and configurations. Nix handles the vim plugins, and I wouldn't to reinstall the vim plugins everytime I cd into a directory.